### PR TITLE
fixed upload WPS office  get extension error

### DIFF
--- a/src/Uploader/Upload.php
+++ b/src/Uploader/Upload.php
@@ -100,7 +100,7 @@ abstract class Upload
      */
     protected function getFileExt()
     {
-        return '.' . $this->file->guessExtension();
+        return '.' . $this->file->guessClientExtension();
     }
 
     /**

--- a/src/Uploader/Upload.php
+++ b/src/Uploader/Upload.php
@@ -100,7 +100,7 @@ abstract class Upload
      */
     protected function getFileExt()
     {
-        return '.' . $this->file->guessClientExtension();
+        return '.' . $this->file->getClientOriginalExtension();
     }
 
     /**


### PR DESCRIPTION
上传WPS office生成的office文件时，xlsx文件会被识别为.BIN文件,使用 guessClientExtension 可以解决这个问题