### PR TITLE
加入阿里云OSS支持

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     "php": ">=5.4.0",
     "ext-fileinfo": "*",
     "illuminate/support": "5.*",
-    "qiniu/php-sdk": "7.*"
+    "qiniu/php-sdk": "7.*",
+    "jacobcyl/ali-oss-storage": "^2.1"
+
   },
   "autoload": {
     "psr-4": {

--- a/src/Uploader/UploadFile.php
+++ b/src/Uploader/UploadFile.php
@@ -1,7 +1,5 @@
 <?php namespace Stevenyangecho\UEditor\Uploader;
 
-use Stevenyangecho\UEditor\Uploader\Upload;
-
 /**
  *
  *
@@ -11,8 +9,10 @@ use Stevenyangecho\UEditor\Uploader\Upload;
  *
  * @package Stevenyangecho\UEditor\Uploader
  */
-class UploadFile  extends Upload{
+class UploadFile extends Upload
+{
     use UploadQiniu;
+
     public function doUpload()
     {
 
@@ -54,7 +54,7 @@ class UploadFile  extends Upload{
             return false;
         }
 
-        if(config('UEditorUpload.core.mode')=='local'){
+        if (config('UEditorUpload.core.mode') == 'local') {
             try {
                 $this->file->move(dirname($this->filePath), $this->fileName);
 
@@ -65,17 +65,21 @@ class UploadFile  extends Upload{
                 return false;
             }
 
-        }else if(config('UEditorUpload.core.mode')=='qiniu'){
+        } else if (config('UEditorUpload.core.mode') == 'qiniu') {
 
-            $content=file_get_contents($this->file->getPathname());
-            return $this->uploadQiniu($this->filePath,$content);
+            $content = file_get_contents($this->file->getPathname());
+            return $this->uploadQiniu($this->filePath, $content);
 
-        }else{
+        } else if (config('UEditorUpload.core.mode') == 'aliyun') {
+            Storage::disk('oss');
+            $content = file_get_contents($this->file->getPathname());
+            // return aliyun oss resource url
+            $this->stateInfo =  Storage::put($this->filePath, $content) ? 'SUCCESS' : $this->getStateInfo("ERROR_UNKNOWN_MODE");
+            $this->fullName = Storage::url($this->fullName);
+        } else {
             $this->stateInfo = $this->getStateInfo("ERROR_UNKNOWN_MODE");
             return false;
         }
-
-
 
 
         return true;


### PR DESCRIPTION
加入阿里云OSS

使用方法 
在 UEditorUpload 修改 mode 为 aliyun  
laravel app/config/filesystems.php disk中加入 

`        'oss' => [
            'driver' => 'oss',
            'access_id' => '',
            'access_key' => '',
            'bucket' =>'',
            'endpoint' => 'oss-cn-hangzhou.aliyuncs.com', // OSS 外网节点或自定义外部域名
            //'endpoint_internal' => '<internal endpoint [OSS内网节点] 如：oss-cn-shenzhen-internal.aliyuncs.com>', // v2.0.4 新增配置属性，如果为空，则默认使用 endpoint 配置(由于内网上传有点小问题未解决，请大家暂时不要使用内网节点上传，正在与阿里技术沟通中)
            'cdnDomain' => 'oss.mub.link', // 如果isCName为true, getUrl会判断cdnDomain是否设定来决定返回的url，如果cdnDomain未设置，则使用endpoint来生成url，否则使用cdn
            'ssl' => false,
            'isCName' => true,
            'debug' => true
        ],`


## 测试环境
laravel-framework 5.5.* 
stevenyangecho/laravel-u-editor v1.4.2
encore/laravel-admin v1.5.5