### PR TITLE
增加使用laravel的storage上传的功能

### DIFF
--- a/config/UEditorUpload.php
+++ b/config/UEditorUpload.php
@@ -21,7 +21,7 @@ return [
            // 'middleware' => 'auth',
         ],
 
-        'mode'=>'local',//上传方式,local 为本地   qiniu 为七牛
+        'mode'=>'local',//上传方式,local 为本地   qiniu 为七牛,storage 为使用laravel的storage
 
         //七牛配置,若mode='qiniu',以下为必填.
         'qiniu'=>[
@@ -30,6 +30,10 @@ return [
             'bucket'=>'',
             'url'=>'http://xxx.clouddn.com',//七牛分配的CDN域名,注意带上http://
 
+        ],
+        'storage'=>[
+            'folder'=>'files',//注意不要加'/'
+            'classifyByFileType'=>false,//是否根据文件类型拆分到子文件夹
         ]
     ],
     /**

--- a/src/Uploader/UploadFile.php
+++ b/src/Uploader/UploadFile.php
@@ -87,6 +87,16 @@ class UploadFile  extends Upload{
                 throw new \Exception(" Upload Files To Server Local Disk Failed On UpYunSdk Driver - 1024. ");
             }
 
+        }else if(config('UEditorUpload.core.mode')=='storage'){
+            //上传文件到oss
+            $folder = config('UEditorUpload.core.storage.folder');
+            if(config('UEditorUpload.core.storage.classifyByFileType')){
+                $folder .='/'. str_replace('.','',$this->fileType);
+            }
+            $path = \Storage::putFile($folder, $this->file);
+            $this->fullName = \Storage::url($path);
+            $this->stateInfo=$this->stateMap[0];
+
         }else{
             $this->stateInfo = $this->getStateInfo("ERROR_UNKNOWN_MODE");
             return false;


### PR DESCRIPTION
配置好默认的文件系统驱动后，在编辑器中，直接采用默认驱动上传图片，不用再单独增加七牛、阿里云等上传文件的方式。统一调用`\Storage::putFile()`来上传文件。